### PR TITLE
authReset custom command and set connection to browserstack to https

### DIFF
--- a/e2e/conf/local.conf.js
+++ b/e2e/conf/local.conf.js
@@ -9,7 +9,7 @@ nightwatch_config = {
   selenium : {
     "start_process" : false,
     "host" : "hub-cloud.browserstack.com",
-    "port" : 80
+    "port" : 443
   },
 
   test_settings: {

--- a/e2e/conf/pipeline.conf.js
+++ b/e2e/conf/pipeline.conf.js
@@ -12,7 +12,7 @@ nightwatch_config = {
   selenium : {
     "start_process" : false,
     "host" : "hub-cloud.browserstack.com",
-    "port" : 80
+    "port" : 443
   },
 
   common_capabilities: {

--- a/e2e/custom-commands/authReset.js
+++ b/e2e/custom-commands/authReset.js
@@ -1,0 +1,41 @@
+var util = require('util');
+var events = require('events');
+var request = require('request');
+
+function authReset() {
+    events.EventEmitter.call(this);
+}
+
+util.inherits(authReset, events.EventEmitter);
+
+authReset.prototype.command = function () {
+
+    var self = this;
+
+    this.api.execute(function(){
+        var token = window.sessionStorage.getItem('KEYCLOAK_TOKEN'); 
+        return token;
+    }, function(result){
+        var auth = 'Bearer ' + result.value;
+        var options = {
+            'method': 'POST',
+            'url': 'https://auth-api-dev.pathfinder.gov.bc.ca/test/reset',
+            'headers': {
+                'Content-Type': 'application/json',
+                'Authorization': auth 
+                }
+        };
+        
+        request(options, function (error, response) { 
+            if (error) {
+                console.log(error);
+            }
+            self.emit('complete');
+        });
+
+    }); 
+
+    return this;
+};
+
+module.exports = authReset;

--- a/e2e/tests/Proof_of_Concept/reset-after.js
+++ b/e2e/tests/Proof_of_Concept/reset-after.js
@@ -1,0 +1,20 @@
+module.exports = {
+    '@tags': ['single'],
+
+    'POST data to the auth reset tool': function (browser) {
+        bcsc = browser.page.bcscPage();
+        browser.url(browser.globals.launch_url);
+        bcsc.loginWithBCSC(process.env.ServiceCard2, process.env.ServiceCard2Pw);
+
+        browser
+            .useCss()
+            .waitForElementVisible('h1.view-header__title');
+    },
+
+    after: function(browser) {
+        browser.authReset();  
+    }
+            
+           
+};
+


### PR DESCRIPTION
*Issue #:*

*Description of changes:*
Proof of concept folder has an example of calling the auth reset endpoint using the keycloak token of the active browser session.
Added authReset custom command
Changed the browserstack connection to port 443

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
