### PR TITLE
Add RCA section to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,3 +33,6 @@ A clear and concise description of what you expected to happen. Use the gherking
 
 **Screenshots/ Visual Reference/ Source**
 If applicable, add screenshots to help explain your problem. You an use screengrab.
+
+**Root Cause Analysis (RCA) results**
+If applicable, document the root cause analysis results for the scenarios. This section is mandatory before the issue can be closed


### PR DESCRIPTION
Added a section for documenting root cause analysis results.

*Issue #:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
